### PR TITLE
Androidでブラウザを開けるようにする対応

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <!-- Provide required visibility configuration for API level 30 and above -->
     <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
有効なURLでiOSで開けるがAndroidでは開けなかったのでcanLaunchUrl() を確認したところ必ずfalseで判定されているようでした。

https://pub.dev/packages/url_launcher#android を参考にしてManifest fileを更新しました。

> Add any URL schemes passed to canLaunchUrl as <queries> entries in your AndroidManifest.xml, otherwise it will return false in most cases starting on Android 11 (API 30) or higher. A <queries> element must be added to your manifest as a child of the root element. 

## 改修後キャプチャ

https://github.com/FlutterKaigi/conference-app-2023/assets/31891340/f94f9ec6-1555-48f7-aca6-6869b424d751

