### PR TITLE
fix fvm document link

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,7 +29,7 @@ flutter upgrade
 3. `fvm flutter pub get`コマンドを実行する。
 4. IDEをfvmを利用するように設定する。
    a. [VSCode](https://code.visualstudio.com/)を利用する場合は、すでに設定済みです。
-   b. [Android Studio](https://developer.android.com/studio)を利用する場合は、[fvmのドキュメント](https://fvm.app/docs/using)を参照してください。
+   b. [Android Studio](https://developer.android.com/studio)を利用する場合は、[fvmのドキュメント](https://fvm.app/docs/getting_started/configuration/#android-studio)を参照してください。
 
 ### コントリビュート
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ flutter upgrade
 3. Run `fvm flutter pub get` command.
 4. Set up IDE to use fvm.
    a. If you use [VSCode](https://code.visualstudio.com/), already set up.
-   b. If you use [Android Studio](https://developer.android.com/studio), please see [fvm document](https://fvm.app/docs/using).
+   b. If you use [Android Studio](https://developer.android.com/studio), please see [fvm document](https://fvm.app/docs/getting_started/configuration/#android-studio).
 
 ### Contributing
 


### PR DESCRIPTION
I fixed fvm document link

| before | after |
|---|---|
| <img width="1100" alt="Screenshot 2023-09-04 at 20 07 45" src="https://github.com/FlutterKaigi/conference-app-2023/assets/6395886/1103f8de-fd8f-4f87-8ea6-f8aa85cf64d5"> | <img width="1208" alt="Screenshot 2023-09-04 at 20 11 26" src="https://github.com/FlutterKaigi/conference-app-2023/assets/6395886/c08067eb-82d0-471b-a2a4-79dc1b2c6301"> |
