### PR TITLE
Add discord link

### DIFF
--- a/lib/l10n/localization.dart
+++ b/lib/l10n/localization.dart
@@ -46,6 +46,8 @@ abstract base class Localization {
 
   String get medium;
 
+  String get discord;
+
   String get pageTitleHome;
 
   String get pageTitleSessions;

--- a/lib/l10n/localization_en.dart
+++ b/lib/l10n/localization_en.dart
@@ -34,7 +34,7 @@ final class LocalizationEn extends Localization {
 
   @override
   String get discord => 'Discord';
-  
+
   @override
   String get pageTitleHome => 'Home';
 

--- a/lib/l10n/localization_en.dart
+++ b/lib/l10n/localization_en.dart
@@ -33,6 +33,9 @@ final class LocalizationEn extends Localization {
   String get medium => 'Medium';
 
   @override
+  String get discord => 'Discord';
+  
+  @override
   String get pageTitleHome => 'Home';
 
   @override

--- a/lib/l10n/localization_ja.dart
+++ b/lib/l10n/localization_ja.dart
@@ -33,6 +33,9 @@ final class LocalizationJa extends Localization {
   String get medium => 'Medium';
 
   @override
+  String get discord => 'Discord';
+
+  @override
   String get pageTitleHome => 'ホーム';
 
   @override

--- a/lib/ui/screen/home.dart
+++ b/lib/ui/screen/home.dart
@@ -101,6 +101,13 @@ class HomePage extends ConsumerWidget {
               ),
               OutlinedButton(
                 onPressed: () async {
+                  final uri = Uri.parse('https://medium.com/flutterkaigi');
+                  await launchInExternalApp(uri);
+                },
+                child: Text(localization.medium),
+              ),
+              OutlinedButton(
+                onPressed: () async {
                   final uri = Uri.parse('https://github.com/FlutterKaigi');
                   await launchInExternalApp(uri);
                 },
@@ -108,14 +115,8 @@ class HomePage extends ConsumerWidget {
               ),
               OutlinedButton(
                 onPressed: () async {
-                  final uri = Uri.parse('https://medium.com/flutterkaigi');
-                  await launchInExternalApp(uri);
-                },
-                child: Text(localization.medium),
-              ),
-               OutlinedButton(
-                onPressed: () async {
-                  final uri = Uri.parse('https://discord.com/invite/Nr7H8JTJSF');
+                  final uri =
+                      Uri.parse('https://discord.com/invite/Nr7H8JTJSF');
                   await launchInExternalApp(uri);
                 },
                 child: Text(localization.discord),

--- a/lib/ui/screen/home.dart
+++ b/lib/ui/screen/home.dart
@@ -89,6 +89,8 @@ class HomePage extends ConsumerWidget {
           const Gap(16),
           Wrap(
             spacing: 16,
+            runSpacing: 16,
+            alignment: WrapAlignment.center,
             children: [
               OutlinedButton(
                 onPressed: () async {
@@ -110,6 +112,13 @@ class HomePage extends ConsumerWidget {
                   await launchInExternalApp(uri);
                 },
                 child: Text(localization.medium),
+              ),
+               OutlinedButton(
+                onPressed: () async {
+                  final uri = Uri.parse('https://discord.com/invite/Nr7H8JTJSF');
+                  await launchInExternalApp(uri);
+                },
+                child: Text(localization.discord),
               ),
             ],
           ),


### PR DESCRIPTION
## Overview
close #100 

Add discord link to home screen.

## Changes

- Added `discord` localization support to existing localization classes.
- Implemented an outlined Discord button on the home screen.
- Changed the display order of Medium and GitHub buttons on the home screen.
- Modified line spacing and alignment in the `Wrap` class.

## Screen shots

### Android
<img src="https://github.com/FlutterKaigi/conference-app-2023/assets/1630075/e2c9e240-7075-4a1f-b351-ed49a67b5ce9" width="240" />

### iOS
<img src="https://github.com/FlutterKaigi/conference-app-2023/assets/1630075/bee4425d-a896-47d5-bd34-b8900b9aba42" width="240" />


### Web
![image](https://github.com/FlutterKaigi/conference-app-2023/assets/1630075/642fa5d0-569a-4ecb-bbd0-83e36a89c790)
