### PR TITLE
Set Center-aligned TopAppBar on Root screen

### DIFF
--- a/lib/ui/screen/root.dart
+++ b/lib/ui/screen/root.dart
@@ -35,6 +35,7 @@ class RootScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(currentTab.title(localization)),
+        centerTitle: true,
       ),
       drawer: switch (screenSize) {
         ScreenSize.compact => RootDrawer(

--- a/lib/ui/theme.dart
+++ b/lib/ui/theme.dart
@@ -9,9 +9,6 @@ part 'theme.g.dart';
 ThemeData theme(ThemeRef ref, ColorScheme? colorScheme) {
   final baseTheme = ThemeData(
     colorScheme: colorScheme ?? lightDefaultColorScheme,
-    appBarTheme: const AppBarTheme(
-      centerTitle: true,
-    ),
     useMaterial3: true,
   );
 
@@ -26,9 +23,6 @@ ThemeData theme(ThemeRef ref, ColorScheme? colorScheme) {
 ThemeData darkTheme(DarkThemeRef ref, ColorScheme? colorScheme) {
   final baseTheme = ThemeData(
     colorScheme: colorScheme ?? darkDefaultColorScheme,
-    appBarTheme: const AppBarTheme(
-      centerTitle: true,
-    ),
     useMaterial3: true,
   );
 

--- a/lib/ui/theme.dart
+++ b/lib/ui/theme.dart
@@ -9,6 +9,9 @@ part 'theme.g.dart';
 ThemeData theme(ThemeRef ref, ColorScheme? colorScheme) {
   final baseTheme = ThemeData(
     colorScheme: colorScheme ?? lightDefaultColorScheme,
+    appBarTheme: const AppBarTheme(
+      centerTitle: true,
+    ),
     useMaterial3: true,
   );
 
@@ -23,6 +26,9 @@ ThemeData theme(ThemeRef ref, ColorScheme? colorScheme) {
 ThemeData darkTheme(DarkThemeRef ref, ColorScheme? colorScheme) {
   final baseTheme = ThemeData(
     colorScheme: colorScheme ?? darkDefaultColorScheme,
+    appBarTheme: const AppBarTheme(
+      centerTitle: true,
+    ),
     useMaterial3: true,
   );
 


### PR DESCRIPTION
# Overview
Android端末でAppBarのタイトルが中央によるようにしました。全てのScaffoldのtitleをcenteringしました。
[Figma](https://www.figma.com/file/x71sECvdnsw8RTfKG0E4fB/FlutterKaigi-2023-App?type=design&node-id=11-1833&mode=design&t=ndHREE2ygRmmPXm3-0) をみました。

# CheckList
- Android
pixel 5aでタイトルがcenteringされることを確認しました。
<img src="https://github.com/FlutterKaigi/conference-app-2023/assets/40790076/525e0ba4-3752-429b-9e7a-8967db6ad876" width=200>

- iOS
<img src="https://github.com/FlutterKaigi/conference-app-2023/assets/40790076/2678b37f-f60d-4ab7-972a-574cab0df768" width=200>

- Web
<img width="400" alt="スクリーンショット 2023-09-06 2 46 33" src="https://github.com/FlutterKaigi/conference-app-2023/assets/40790076/374ccf52-d21f-4c94-a21e-1d50b474ab27">
