### PR TITLE
fix: indent for Markdown preview on GitHub

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -28,8 +28,8 @@ flutter upgrade
 2. プロジェクトのルートディレクトリに移動し、`fvm install`コマンドを実行する。
 3. `fvm flutter pub get`コマンドを実行する。
 4. IDEをfvmを利用するように設定する。
-   a. [VSCode](https://code.visualstudio.com/)を利用する場合は、すでに設定済みです。
-   b. [Android Studio](https://developer.android.com/studio)を利用する場合は、[fvmのドキュメント](https://fvm.app/docs/getting_started/configuration/#android-studio)を参照してください。
+    - [VSCode](https://code.visualstudio.com/)を利用する場合は、すでに設定済みです。
+    - [Android Studio](https://developer.android.com/studio)を利用する場合は、[fvmのドキュメント](https://fvm.app/docs/getting_started/configuration/#android-studio)を参照してください。
 
 ### コントリビュート
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -28,8 +28,8 @@ flutter upgrade
 2. プロジェクトのルートディレクトリに移動し、`fvm install`コマンドを実行する。
 3. `fvm flutter pub get`コマンドを実行する。
 4. IDEをfvmを利用するように設定する。
-    - [VSCode](https://code.visualstudio.com/)を利用する場合は、すでに設定済みです。
-    - [Android Studio](https://developer.android.com/studio)を利用する場合は、[fvmのドキュメント](https://fvm.app/docs/getting_started/configuration/#android-studio)を参照してください。
+   - [VSCode](https://code.visualstudio.com/)を利用する場合は、すでに設定済みです。
+   - [Android Studio](https://developer.android.com/studio)を利用する場合は、[fvmのドキュメント](https://fvm.app/docs/getting_started/configuration/#android-studio)を参照してください。
 
 ### コントリビュート
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ flutter upgrade
 2. Move to project root directory, and run `fvm install` command.
 3. Run `fvm flutter pub get` command.
 4. Set up IDE to use fvm.
-    - If you use [VSCode](https://code.visualstudio.com/), already set up.
-    - If you use [Android Studio](https://developer.android.com/studio), please see [fvm document](https://fvm.app/docs/getting_started/configuration/#android-studio).
+   - If you use [VSCode](https://code.visualstudio.com/), already set up.
+   - If you use [Android Studio](https://developer.android.com/studio), please see [fvm document](https://fvm.app/docs/getting_started/configuration/#android-studio).
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ flutter upgrade
 2. Move to project root directory, and run `fvm install` command.
 3. Run `fvm flutter pub get` command.
 4. Set up IDE to use fvm.
-   a. If you use [VSCode](https://code.visualstudio.com/), already set up.
-   b. If you use [Android Studio](https://developer.android.com/studio), please see [fvm document](https://fvm.app/docs/getting_started/configuration/#android-studio).
+    - If you use [VSCode](https://code.visualstudio.com/), already set up.
+    - If you use [Android Studio](https://developer.android.com/studio), please see [fvm document](https://fvm.app/docs/getting_started/configuration/#android-studio).
 
 ### Contributing
 


### PR DESCRIPTION
## 理由
GitHub上でREADMEを確認した際に、以下の部分が表示崩れしていると感じました。
（4.にある、"a."や"b."の部分が、1行に表示されている）

`README.md`
![image](https://github.com/FlutterKaigi/conference-app-2023/assets/1567757/2a18aa2b-42b9-43e9-a707-6f277a19ffb6)

`README.ja.md`
![image](https://github.com/FlutterKaigi/conference-app-2023/assets/1567757/3b847c43-867d-4685-925f-a48bb5e06f5b)

## 原因
コードを確認すると、スペースが3つになっていました。

## 解決策
改めて内容を確認すると、「VSCodeの場合」と「Android Studioの場合」という並列のもの（1. 2.といった形で、順序が必要なものではない）と感じたので、 `- ` に置き換えました。

結果としては、以下の表示となりました。
https://github.com/noboru-i/conference-app-2023/blob/fix-indent-readme/README.md#install-flutter-beta-channel-with-fvm
![image](https://github.com/FlutterKaigi/conference-app-2023/assets/1567757/affa82c3-030e-4a9e-9c79-f62614513cf8)

https://github.com/noboru-i/conference-app-2023/blob/fix-indent-readme/README.ja.md#fvm%E3%82%92%E5%88%A9%E7%94%A8%E3%81%97%E3%81%A6flutter-beta-channel%E3%82%92%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%99%E3%82%8B
![image](https://github.com/FlutterKaigi/conference-app-2023/assets/1567757/930d8693-cc23-4741-8f81-fcc5d31e89a0)
