### PR TITLE
fix: initial index on contributors tab

### DIFF
--- a/lib/ui/screen/contributors/contributors.dart
+++ b/lib/ui/screen/contributors/contributors.dart
@@ -45,6 +45,7 @@ class _ContributorsPageState extends ConsumerState<ContributorsPage>
     _tabController = TabController(
       vsync: this,
       length: ContributorsTab.values.length,
+      initialIndex: widget.tab.index,
     )..addListener(_onChangeTab);
   }
 


### PR DESCRIPTION
## Description

* set a initial index from `ContributorsTab.index`  

Fixes #issue_number
#149 

## Type of change
- [x] Bug fix

## How Has This Been Tested?
- reload the screen checking...

|  before |  after  |
| ---- | ---- |
| ![image](https://github.com/FlutterKaigi/conference-app-2023/assets/885696/2c3ba364-7212-472c-97ea-a1dc5b904acc) | ![image](https://github.com/FlutterKaigi/conference-app-2023/assets/885696/d8682e7b-cf55-4f98-8a03-7bc306908e41)  |


https://github.com/FlutterKaigi/conference-app-2023/assets/885696/151f5ead-dfcb-4764-8b3c-8ce2caa4ec44



## Checklist

- [x] My code follows the style guidelines of this project.
- [x] My code has been formatted with `flutter format lib`.
- [x] My code has been fixed with `dart fix --apply lib`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
