### PR TITLE
feat: add animation on router branch changing

### DIFF
--- a/lib/ui/router/branch_container.dart
+++ b/lib/ui/router/branch_container.dart
@@ -18,7 +18,9 @@ class BranchContainer extends StatelessWidget {
       children: [
         ...children.mapIndexed(
           (index, navigator) => AnimatedOpacity(
-            duration: const Duration(milliseconds: 400),
+            duration: const Duration(
+              milliseconds: 400,
+            ),
             opacity: index == currentIndex ? 1 : 0,
 
             // Avoid detecting tap event in non selected screen

--- a/lib/ui/router/branch_container.dart
+++ b/lib/ui/router/branch_container.dart
@@ -17,8 +17,8 @@ class BranchContainer extends StatelessWidget {
     return Stack(
       children: [
         ...children.mapIndexed(
-          (index, navigator) => Opacity(
-            // TODO: [https://github.com/FlutterKaigi/conference-app-2023/issues/145]
+          (index, navigator) => AnimatedOpacity(
+            duration: const Duration(milliseconds: 400),
             opacity: index == currentIndex ? 1 : 0,
 
             // Avoid detecting tap event in non selected screen


### PR DESCRIPTION
## Description

* add `AnimatedOpacity` on route branch changing with reference of [the go_router's example](https://github.com/flutter/packages/blob/4becde9adc9b4f05710179252a18d0c1b8c8f3a9/packages/go_router/example/lib/others/custom_stateful_shell_route.dart#L239C39-L254)
* not add `AnimatedScale` or other animation

Fixes #145

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Style
- [ ] Documentation
- [ ] CI/CD
- [ ] Other

## How Has This Been Tested?

* switch pages with bottom navigation tab or drawer

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] My code has been formatted with `flutter format lib`.
- [x] My code has been fixed with `dart fix --apply lib`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
