### PR TITLE
style: Sponsors category title align changed from left to center

### DIFF
--- a/lib/ui/screen/sponsors/sponsors.dart
+++ b/lib/ui/screen/sponsors/sponsors.dart
@@ -31,9 +31,11 @@ class SponsorsPage extends ConsumerWidget {
                   const SliverGap(16),
                   SliverPaddingBoxToAdapter(
                     padding: padding,
-                    child: Text(
-                      localizations.sponsorPlatinum,
-                      style: Theme.of(context).textTheme.titleLarge,
+                    child: Center(
+                      child: Text(
+                        localizations.sponsorPlatinum,
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
                     ),
                   ),
                   const SliverGap(16),
@@ -52,9 +54,11 @@ class SponsorsPage extends ConsumerWidget {
                   const SliverGap(16),
                   SliverPaddingBoxToAdapter(
                     padding: padding,
-                    child: Text(
-                      localizations.sponsorGold,
-                      style: Theme.of(context).textTheme.titleLarge,
+                    child: Center(
+                      child: Text(
+                        localizations.sponsorGold,
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
                     ),
                   ),
                   const SliverGap(16),
@@ -79,9 +83,11 @@ class SponsorsPage extends ConsumerWidget {
                   const SliverGap(16),
                   SliverPaddingBoxToAdapter(
                     padding: padding,
-                    child: Text(
-                      localizations.sponsorSilver,
-                      style: Theme.of(context).textTheme.titleLarge,
+                    child: Center(
+                      child: Text(
+                        localizations.sponsorSilver,
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
                     ),
                   ),
                   const SliverGap(16),


### PR DESCRIPTION
## Description

* Wrapped sponsor category text with [Center Widget](https://api.flutter.dev/flutter/widgets/Center-class.html)

Fixes #170 

## Type of change

- [x] Style

## How Has This Been Tested?

* Checked the display locally before and after changes

| before | after |
| --- | --- |
| <img width="200" alt="before_sponsors-category-title" src="https://github.com/FlutterKaigi/conference-app-2023/assets/56357240/be3595bb-211e-4a76-9f6e-3bd4a3437526"> | <img width="200" alt="after_sponsors_category-title" src="https://github.com/FlutterKaigi/conference-app-2023/assets/56357240/ea776364-463b-42c3-9085-8a6ffc4f197d"> |

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] My code has been formatted with `flutter format lib`.
- [x] My code has been fixed with `dart fix --apply lib`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
