### PR TITLE
feat: favorite sessions feature (add IconButton & visible in the sessions page)

### DIFF
--- a/lib/model/favorites/favorite_session_ids.dart
+++ b/lib/model/favorites/favorite_session_ids.dart
@@ -10,7 +10,7 @@ class FavoriteSessionIdsNotifier extends _$FavoriteSessionIdsNotifier {
   @override
   List<String> build() {
     final sharedPreferences = ref.watch(sharedPreferencesProvider);
-    return sharedPreferences.getStringList(_key) ?? [];
+    return sharedPreferences.getStringList(_key) ?? const [];
   }
 
   Future<void> add(String id) async {

--- a/lib/model/favorites/favorite_session_ids.dart
+++ b/lib/model/favorites/favorite_session_ids.dart
@@ -1,31 +1,29 @@
 import 'package:conference_2023/model/shared_preferences.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 part 'favorite_session_ids.g.dart';
 
 @riverpod
 class FavoriteSessionIdsNotifier extends _$FavoriteSessionIdsNotifier {
-  String get _storageKey => SharedPreferenceKey.favoriteSessionIds.value;
-
-  SharedPreferences get _sharedPreferences =>
-      ref.read(sharedPreferencesProvider);
+  String get _key => SharedPreferenceKey.favoriteSessionIds.value;
 
   @override
   List<String> build() {
-    return _sharedPreferences.getStringList(_storageKey) ?? [];
+    final sharedPreferences = ref.watch(sharedPreferencesProvider);
+    return sharedPreferences.getStringList(_key) ?? [];
   }
 
   Future<void> add(String id) async {
-    await _updateFavoriteIds([...state, id]);
+    await _updateFavoriteSessionIds([...state, id]);
   }
 
   Future<void> remove(String id) async {
-    await _updateFavoriteIds(state.where((e) => e != id).toList());
+    await _updateFavoriteSessionIds(state.where((e) => e != id).toList());
   }
 
-  Future<void> _updateFavoriteIds(List<String> ids) async {
+  Future<void> _updateFavoriteSessionIds(List<String> ids) async {
+    final sharedPreferences = ref.read(sharedPreferencesProvider);
+    await sharedPreferences.setStringList(_key, ids);
     state = ids;
-    await _sharedPreferences.setStringList(_storageKey, state);
   }
 }

--- a/lib/model/favorites/favorite_session_ids.dart
+++ b/lib/model/favorites/favorite_session_ids.dart
@@ -1,0 +1,31 @@
+import 'package:conference_2023/model/shared_preferences.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'favorite_session_ids.g.dart';
+
+@riverpod
+class FavoriteSessionIdsNotifier extends _$FavoriteSessionIdsNotifier {
+  String get _storageKey => SharedPreferenceKey.favoriteSessionIds.value;
+
+  SharedPreferences get _sharedPreferences =>
+      ref.read(sharedPreferencesProvider);
+
+  @override
+  List<String> build() {
+    return _sharedPreferences.getStringList(_storageKey) ?? [];
+  }
+
+  Future<void> add(String id) async {
+    await _updateFavoriteIds([...state, id]);
+  }
+
+  Future<void> remove(String id) async {
+    await _updateFavoriteIds(state.where((e) => e != id).toList());
+  }
+
+  Future<void> _updateFavoriteIds(List<String> ids) async {
+    state = ids;
+    await _sharedPreferences.setStringList(_storageKey, state);
+  }
+}

--- a/lib/model/favorites/favorite_session_ids.g.dart
+++ b/lib/model/favorites/favorite_session_ids.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'favorite_session_ids.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$favoriteSessionIdsNotifierHash() =>
+    r'13ad49625cb953969efc60c6c129f25e36a3baf9';
+
+/// See also [FavoriteSessionIdsNotifier].
+@ProviderFor(FavoriteSessionIdsNotifier)
+final favoriteSessionIdsNotifierProvider = AutoDisposeNotifierProvider<
+    FavoriteSessionIdsNotifier, List<String>>.internal(
+  FavoriteSessionIdsNotifier.new,
+  name: r'favoriteSessionIdsNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$favoriteSessionIdsNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$FavoriteSessionIdsNotifier = AutoDisposeNotifier<List<String>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/model/favorites/favorite_session_ids.g.dart
+++ b/lib/model/favorites/favorite_session_ids.g.dart
@@ -7,7 +7,7 @@ part of 'favorite_session_ids.dart';
 // **************************************************************************
 
 String _$favoriteSessionIdsNotifierHash() =>
-    r'13ad49625cb953969efc60c6c129f25e36a3baf9';
+    r'81eece064524ce2aba87219be6c5f3f10e2d880e';
 
 /// See also [FavoriteSessionIdsNotifier].
 @ProviderFor(FavoriteSessionIdsNotifier)

--- a/lib/model/shared_preferences.dart
+++ b/lib/model/shared_preferences.dart
@@ -13,6 +13,7 @@ enum SharedPreferenceKey {
   themeMode('theme_mode'),
   localizationMode('localization_mode'),
   fontFamily('font_family'),
+  favoriteSessionIds('favorite_session_ids'),
   ;
 
   const SharedPreferenceKey(this.value);

--- a/lib/ui/screen/sessions/session_detail.dart
+++ b/lib/ui/screen/sessions/session_detail.dart
@@ -1,6 +1,7 @@
 import 'package:conference_2023/gen/assets.gen.dart';
 import 'package:conference_2023/l10n/localization.dart';
 import 'package:conference_2023/model/app_locale.dart';
+import 'package:conference_2023/model/favorites/favorite_session_ids.dart';
 import 'package:conference_2023/model/sessions/session.dart';
 import 'package:conference_2023/model/sessions/session_provider.dart';
 import 'package:conference_2023/util/extension/build_context_ext.dart';
@@ -35,6 +36,8 @@ class SessionDetailPage extends ConsumerWidget {
         d,
       _ => null,
     };
+    final favoriteSessionIds = ref.watch(favoriteSessionIdsNotifierProvider);
+    final isFavorite = favoriteSessionIds.contains(sessionId);
 
     return SingleChildScrollView(
       padding: EdgeInsets.symmetric(
@@ -44,9 +47,30 @@ class SessionDetailPage extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            session.title.get(locale),
-            style: Theme.of(context).textTheme.headlineMedium,
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  session.title.get(locale),
+                  style: Theme.of(context).textTheme.headlineMedium,
+                ),
+              ),
+              IconButton(
+                iconSize: 28,
+                icon: Icon(
+                  isFavorite ? Icons.favorite : Icons.favorite_border,
+                ),
+                onPressed: () async {
+                  isFavorite
+                      ? await ref
+                          .read(favoriteSessionIdsNotifierProvider.notifier)
+                          .remove(sessionId)
+                      : await ref
+                          .read(favoriteSessionIdsNotifierProvider.notifier)
+                          .add(sessionId);
+                },
+              ),
+            ],
           ),
           const Gap(8),
           Container(

--- a/lib/ui/screen/sessions/session_detail.dart
+++ b/lib/ui/screen/sessions/session_detail.dart
@@ -36,8 +36,11 @@ class SessionDetailPage extends ConsumerWidget {
         d,
       _ => null,
     };
-    final favoriteSessionIds = ref.watch(favoriteSessionIdsNotifierProvider);
-    final isFavorite = favoriteSessionIds.contains(sessionId);
+    final isFavorite = ref.watch(
+      favoriteSessionIdsNotifierProvider.select(
+        (favoriteSessionIds) => favoriteSessionIds.contains(sessionId),
+      ),
+    );
 
     return SingleChildScrollView(
       padding: EdgeInsets.symmetric(
@@ -56,7 +59,6 @@ class SessionDetailPage extends ConsumerWidget {
                 ),
               ),
               IconButton(
-                iconSize: 28,
                 icon: Icon(
                   isFavorite ? Icons.favorite : Icons.favorite_border,
                 ),

--- a/lib/ui/screen/sessions/sessions.dart
+++ b/lib/ui/screen/sessions/sessions.dart
@@ -1,5 +1,6 @@
 import 'package:conference_2023/l10n/localization.dart';
 import 'package:conference_2023/model/app_locale.dart';
+import 'package:conference_2023/model/favorites/favorite_session_ids.dart';
 import 'package:conference_2023/model/sessions/session.dart';
 import 'package:conference_2023/model/sessions/session_provider.dart';
 import 'package:conference_2023/ui/router/router_app.dart';
@@ -139,6 +140,7 @@ class _SessionCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final locale = ref.watch(appLocaleProvider);
+    final favoriteSessionIds = ref.watch(favoriteSessionIdsNotifierProvider);
 
     final speakerName = switch (session) {
       SessionSponsor(speaker: final s) => Wrap(
@@ -162,6 +164,15 @@ class _SessionCard extends ConsumerWidget {
       _ => null,
     };
 
+    final trailingFavorite = switch (session) {
+      SessionSponsor(id: final i) || SessionTalk(id: final i) => Icon(
+          favoriteSessionIds.contains(i)
+              ? Icons.favorite
+              : Icons.favorite_border,
+        ),
+      _ => null,
+    };
+
     return Card(
       elevation: 0,
       shape: RoundedRectangleBorder(
@@ -172,11 +183,12 @@ class _SessionCard extends ConsumerWidget {
       ),
       child: ListTile(
         title: Text(session.title.get(locale)),
-        contentPadding: const EdgeInsets.only(
-          left: 16,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
         ),
         subtitle: speakerName,
         leading: leadingImage,
+        trailing: trailingFavorite,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
         ),


### PR DESCRIPTION
## Description

* Add an IconButton to the session details page and add it to favorites when pressed. 6dd5236cb2b8f9ac8846aadec055113a1388d939
  * Only session IDs added to favorites are stored in `shared_preferences` (key: `favorite_session_ids`).
* Make favorites visible in the sessions page 2dba1b9f7b72363ba384a5aa25b40f4a8f73a111

Refs #174 

## Type of change

- [x] New feature

## How Has This Been Tested?

* Session IDs added to favorites are stored in local storage.
* Only sessions added to favorites are filled ❤️ .

![favorite_sessions](https://github.com/FlutterKaigi/conference-app-2023/assets/56357240/bb319335-58cb-4411-be53-f20bb96b935f)

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] My code has been formatted with `flutter format lib`.
- [x] My code has been fixed with `dart fix --apply lib`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
