### PR TITLE
fix: Hide selected icon to show room name

### DIFF
--- a/lib/ui/screen/sessions/sessions.dart
+++ b/lib/ui/screen/sessions/sessions.dart
@@ -31,6 +31,7 @@ class SessionsPage extends ConsumerWidget {
           Container(
             alignment: Alignment.center,
             child: SegmentedButton<Room>(
+              showSelectedIcon: false,
               segments: [
                 ButtonSegment(
                   value: Room.room1,


### PR DESCRIPTION
## Description

* Hide the selected icon to display the room name.

Pixel 7a

| before | after |
| :---: | :---: |
| <img src="https://github.com/FlutterKaigi/conference-app-2023/assets/17231507/965c31d6-b4b4-44ea-8a1a-8487b458d536" width="200"> | <img src="https://github.com/FlutterKaigi/conference-app-2023/assets/17231507/7bdff603-75e7-4f97-aecc-0188f527c6ef" width="200"> |

## Type of change

- [x] Style

## How Has This Been Tested?

Build, screenshot.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] My code has been formatted with `flutter format lib`.
- [x] My code has been fixed with `dart fix --apply lib`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
