### PR TITLE
style: Move favorites button / Add twitter share button

### DIFF
--- a/lib/l10n/localization.dart
+++ b/lib/l10n/localization.dart
@@ -48,6 +48,8 @@ abstract base class Localization {
 
   String get twitterTooltip;
 
+  String get tweetTooltip;
+
   String get github;
 
   String get githubTooltip;

--- a/lib/l10n/localization.dart
+++ b/lib/l10n/localization.dart
@@ -100,6 +100,10 @@ abstract base class Localization {
 
   String get favoritesSessionEmptyPrompt;
 
+  String get favoritesAddTooltip;
+
+  String get favoritesRemoveTooltip;
+
   String get contributorsDeveloper;
 
   String get contributorsStaff;

--- a/lib/l10n/localization_en.dart
+++ b/lib/l10n/localization_en.dart
@@ -112,6 +112,12 @@ final class LocalizationEn extends Localization {
       'There are no sessions added to favorites.';
 
   @override
+  String get favoritesAddTooltip => 'Add to favorites';
+
+  @override
+  String get favoritesRemoveTooltip => 'Remove from favorites';
+
+  @override
   String get contributorsDeveloper => 'Developer';
 
   @override

--- a/lib/l10n/localization_en.dart
+++ b/lib/l10n/localization_en.dart
@@ -33,6 +33,9 @@ final class LocalizationEn extends Localization {
   String get twitterTooltip => 'Open Twitter';
 
   @override
+  String get tweetTooltip => 'Tweet';
+
+  @override
   String get github => 'GitHub';
 
   @override

--- a/lib/l10n/localization_ja.dart
+++ b/lib/l10n/localization_ja.dart
@@ -111,6 +111,12 @@ final class LocalizationJa extends Localization {
   String get favoritesSessionEmptyPrompt => 'お気に入り登録したセッションがありません。';
 
   @override
+  String get favoritesAddTooltip => 'お気に入りに追加する';
+
+  @override
+  String get favoritesRemoveTooltip => 'お気に入りから削除する';
+
+  @override
   String get contributorsDeveloper => '開発者';
 
   @override

--- a/lib/l10n/localization_ja.dart
+++ b/lib/l10n/localization_ja.dart
@@ -33,6 +33,9 @@ final class LocalizationJa extends Localization {
   String get twitterTooltip => 'Twitterを開く';
 
   @override
+  String get tweetTooltip => 'ツイートする';
+
+  @override
   String get github => 'GitHub';
 
   @override

--- a/lib/ui/screen/sessions/session_detail.dart
+++ b/lib/ui/screen/sessions/session_detail.dart
@@ -50,10 +50,6 @@ class SessionDetailPage extends ConsumerWidget {
               isFavorite ? Icons.favorite : Icons.favorite_border,
               color: Theme.of(context).colorScheme.primary,
             ),
-            constraints: const BoxConstraints(
-              minHeight: kToolbarHeight,
-              minWidth: kToolbarHeight,
-            ),
             tooltip: isFavorite
                 ? localization.favoritesRemoveTooltip
                 : localization.favoritesAddTooltip,
@@ -74,10 +70,6 @@ class SessionDetailPage extends ConsumerWidget {
                 Theme.of(context).colorScheme.onSurface,
                 BlendMode.srcIn,
               ),
-            ),
-            constraints: const BoxConstraints(
-              minHeight: kToolbarHeight,
-              minWidth: kToolbarHeight,
             ),
             tooltip: localization.tweetTooltip,
             onPressed: () async {

--- a/lib/ui/screen/sessions/session_detail.dart
+++ b/lib/ui/screen/sessions/session_detail.dart
@@ -44,7 +44,26 @@ class SessionDetailPage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(localization.pageTitleSessions),
+        actions: [
+          IconButton(
+            icon: Icon(
+              isFavorite ? Icons.favorite : Icons.favorite_border,
+            ),
+            constraints: const BoxConstraints(
+              minHeight: kToolbarHeight,
+              minWidth: kToolbarHeight,
+            ),
+            onPressed: () async {
+              isFavorite
+                  ? await ref
+                      .read(favoriteSessionIdsNotifierProvider.notifier)
+                      .remove(sessionId)
+                  : await ref
+                      .read(favoriteSessionIdsNotifierProvider.notifier)
+                      .add(sessionId);
+            },
+          ),
+        ],
       ),
       body: SingleChildScrollView(
         padding: EdgeInsets.symmetric(
@@ -54,29 +73,9 @@ class SessionDetailPage extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    session.title.get(locale),
-                    style: Theme.of(context).textTheme.headlineMedium,
-                  ),
-                ),
-                IconButton(
-                  icon: Icon(
-                    isFavorite ? Icons.favorite : Icons.favorite_border,
-                  ),
-                  onPressed: () async {
-                    isFavorite
-                        ? await ref
-                            .read(favoriteSessionIdsNotifierProvider.notifier)
-                            .remove(sessionId)
-                        : await ref
-                            .read(favoriteSessionIdsNotifierProvider.notifier)
-                            .add(sessionId);
-                  },
-                ),
-              ],
+            Text(
+              session.title.get(locale),
+              style: Theme.of(context).textTheme.headlineMedium,
             ),
             const Gap(8),
             Container(

--- a/lib/ui/screen/sessions/session_detail.dart
+++ b/lib/ui/screen/sessions/session_detail.dart
@@ -68,7 +68,13 @@ class SessionDetailPage extends ConsumerWidget {
             },
           ),
           IconButton(
-            icon: Assets.svg.xLogo.svg(width: 18),
+            icon: Assets.svg.xLogo.svg(
+              width: 18,
+              colorFilter: ColorFilter.mode(
+                Theme.of(context).colorScheme.onSurface,
+                BlendMode.srcIn,
+              ),
+            ),
             constraints: const BoxConstraints(
               minHeight: kToolbarHeight,
               minWidth: kToolbarHeight,

--- a/lib/ui/screen/sessions/session_detail.dart
+++ b/lib/ui/screen/sessions/session_detail.dart
@@ -66,6 +66,20 @@ class SessionDetailPage extends ConsumerWidget {
                       .add(sessionId);
             },
           ),
+          IconButton(
+            icon: Assets.svg.xLogo.svg(width: 18),
+            constraints: const BoxConstraints(
+              minHeight: kToolbarHeight,
+              minWidth: kToolbarHeight,
+            ),
+            tooltip: localization.tweetTooltip,
+            onPressed: () async {
+              final uri = Uri.parse(
+                'https://twitter.com/share?url=https://flutterkaigi.jp/2023/sessions/$sessionId&hashtags=flutterkaigi&via=FlutterKaigi',
+              );
+              await launchInExternalApp(uri);
+            },
+          ),
         ],
       ),
       body: SingleChildScrollView(

--- a/lib/ui/screen/sessions/session_detail.dart
+++ b/lib/ui/screen/sessions/session_detail.dart
@@ -53,6 +53,9 @@ class SessionDetailPage extends ConsumerWidget {
               minHeight: kToolbarHeight,
               minWidth: kToolbarHeight,
             ),
+            tooltip: isFavorite
+                ? localization.favoritesRemoveTooltip
+                : localization.favoritesAddTooltip,
             onPressed: () async {
               isFavorite
                   ? await ref


### PR DESCRIPTION
## Description

* Rearrange buttons according to [M3 IconButton Placement](https://m3.material.io/components/icon-buttons/guidelines#980e210b-2e69-48e9-8045-d8d432f43db5).
* Set tooltip for accessibility.
* (Optional) Add twitter share button like [FlutterKaigi Web](https://flutterkaigi.jp/2023/sessions/21abbd32-6864-487a-8066-c9d7f7e5e9be).

Fixes #202 

## Type of change

- [x] Style

## How Has This Been Tested?

* The behavior of the add favorites button has not changed.
* When press the twitter share button, the tweet screen opens in external application.

https://github.com/FlutterKaigi/conference-app-2023/assets/56357240/56ff7c25-c772-41d6-a885-a1103873caae

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] My code has been formatted with `flutter format lib`.
- [x] My code has been fixed with `dart fix --apply lib`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
