### PR TITLE
feat: toggle favorite at sessions page

### DIFF
--- a/lib/ui/widget/session_card.dart
+++ b/lib/ui/widget/session_card.dart
@@ -60,9 +60,20 @@ class SessionCard extends ConsumerWidget {
 
     final trailingFavorite = switch (session) {
       SessionSponsor() || SessionTalk() => showFavoriteIcon
-          ? Icon(
+          ? IconButton(
+              icon: Icon(
               isFavorite ? Icons.favorite : Icons.favorite_border,
               color: Theme.of(context).colorScheme.primary,
+              ),
+              onPressed: () async {
+                isFavorite
+                    ? await ref
+                        .read(favoriteSessionIdsNotifierProvider.notifier)
+                        .remove(session.id)
+                    : await ref
+                        .read(favoriteSessionIdsNotifierProvider.notifier)
+                        .add(session.id);
+              },
             )
           : null,
       _ => null,

--- a/lib/ui/widget/session_card.dart
+++ b/lib/ui/widget/session_card.dart
@@ -65,10 +65,10 @@ class SessionCard extends ConsumerWidget {
           ? IconButton(
               tooltip: isFavorite
                   ? localization.favoritesRemoveTooltip
-                  : localization.favoritesAddTooltip
+                  : localization.favoritesAddTooltip,
               icon: Icon(
-              isFavorite ? Icons.favorite : Icons.favorite_border,
-              color: Theme.of(context).colorScheme.primary
+                isFavorite ? Icons.favorite : Icons.favorite_border,
+                color: Theme.of(context).colorScheme.primary,
               ),
               onPressed: () async {
                 isFavorite

--- a/lib/ui/widget/session_card.dart
+++ b/lib/ui/widget/session_card.dart
@@ -1,3 +1,4 @@
+import 'package:conference_2023/l10n/localization.dart';
 import 'package:conference_2023/model/app_locale.dart';
 import 'package:conference_2023/model/favorites/favorite_session_ids.dart';
 import 'package:conference_2023/model/sessions/session.dart';
@@ -18,6 +19,7 @@ class SessionCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final locale = ref.watch(appLocaleProvider);
+    final localization = ref.watch(localizationProvider);
     final isFavorite = ref.watch(
       favoriteSessionIdsNotifierProvider.select(
         (value) => value.contains(session.id),
@@ -61,9 +63,12 @@ class SessionCard extends ConsumerWidget {
     final trailingFavorite = switch (session) {
       SessionSponsor() || SessionTalk() => showFavoriteIcon
           ? IconButton(
+              tooltip: isFavorite
+                  ? localization.favoritesRemoveTooltip
+                  : localization.favoritesAddTooltip
               icon: Icon(
               isFavorite ? Icons.favorite : Icons.favorite_border,
-              color: Theme.of(context).colorScheme.primary,
+              color: Theme.of(context).colorScheme.primary
               ),
               onPressed: () async {
                 isFavorite


### PR DESCRIPTION
## Description
toggle favorite session at the **session list page**.
please kindly consider it🙏 

https://github.com/FlutterKaigi/conference-app-2023/assets/885696/ab199362-fbb9-4df7-9119-660335668606

## Type of change

- [x] New feature


## How Has This Been Tested?

favorite sessions to be registered and remove at the session list page
* platforms:  `Android14` `iOS15`  `web`
* rooms:   `東急(株) URBAN HACKS`,  `⚔️†††開拓者の部屋†††🛡`


## Checklist

- [x] My code follows the style guidelines of this project.
- [x] My code has been formatted with `flutter format lib`.
- [x] My code has been fixed with `dart fix --apply lib`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.





### Android(Android14)
<img src=https://github.com/FlutterKaigi/conference-app-2023/assets/885696/652a7b90-88a6-4c80-bb56-24feedef15bc  width=60%>

### iOS (iOS15)
<img src=https://github.com/FlutterKaigi/conference-app-2023/assets/885696/14f562a0-9301-43c3-8816-f65d6c69162c  width=70%>

### Web
![image](https://github.com/FlutterKaigi/conference-app-2023/assets/885696/d7ef3b94-9f86-4c58-9d1f-592467ffb36d)

