### PR TITLE
Introduce profile edit mode.

### DIFF
--- a/lib/l10n/localization.dart
+++ b/lib/l10n/localization.dart
@@ -217,6 +217,10 @@ abstract base class Localization {
   String get uploadingImage;
 
   String get uploadedImage;
+
+  String get editName;
+
+  String get editUrl;
 }
 
 /// A wrapper class of [DateFormat] for localization.

--- a/lib/l10n/localization_en.dart
+++ b/lib/l10n/localization_en.dart
@@ -297,4 +297,10 @@ final class LocalizationEn extends Localization {
 
   @override
   String get uploadedImage => 'Image uploaded';
+
+  @override
+  String get editName => 'Edit name';
+
+  @override
+  String get editUrl => 'Edit URL';
 }

--- a/lib/l10n/localization_ja.dart
+++ b/lib/l10n/localization_ja.dart
@@ -292,4 +292,10 @@ final class LocalizationJa extends Localization {
 
   @override
   String get uploadedImage => '画像をアップロードしました';
+
+  @override
+  String get editName => '名前を編集する';
+
+  @override
+  String get editUrl => 'URLを編集する';
 }

--- a/lib/model/profile/profile_provider.dart
+++ b/lib/model/profile/profile_provider.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 
 import 'package:conference_2023/model/firebase_auth.dart';
 import 'package:conference_2023/model/firebase_storage.dart';
-import 'package:conference_2023/model/profile/profile.dart';
 import 'package:conference_2023/model/shared_preferences.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -11,50 +10,34 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'profile_provider.g.dart';
 
 @riverpod
-class ProfileNotifier extends _$ProfileNotifier {
-  String get _userNameKey => SharedPreferenceKey.userName.value;
-  String get _websiteUrlKey => SharedPreferenceKey.profileWebsiteUrl.value;
+class UserName extends _$UserName {
+  String get _key => SharedPreferenceKey.userName.value;
 
   @override
-  Future<Profile> build() async {
-    final currentUserIdFuture = ref.watch(currentUserIdProvider.future);
+  String build() {
     final sharedPreference = ref.watch(sharedPreferencesProvider);
-
-    final userId = await currentUserIdFuture;
-
-    return Profile(
-      id: userId ?? '',
-      name: sharedPreference.getString(_userNameKey) ?? '',
-      websiteUrl: sharedPreference.getString(_websiteUrlKey) ?? '',
-    );
+    return sharedPreference.getString(_key) ?? '';
   }
 
-  Future<void> updateName(String name) async {
-    state = await AsyncValue.guard(
-      () async {
-        await ref.read(sharedPreferencesProvider).setString(_userNameKey, name);
-        return update(
-          (profile) => profile.copyWith(
-            name: name,
-          ),
-        );
-      },
-    );
+  Future<void> update(String name) async {
+    await ref.read(sharedPreferencesProvider).setString(_key, name);
+    state = name;
+  }
+}
+
+@riverpod
+class WebsiteUrl extends _$WebsiteUrl {
+  String get _key => SharedPreferenceKey.profileWebsiteUrl.value;
+
+  @override
+  String build() {
+    final sharedPreference = ref.watch(sharedPreferencesProvider);
+    return sharedPreference.getString(_key) ?? '';
   }
 
-  Future<void> updateWebsiteUrl(String url) async {
-    state = await AsyncValue.guard(
-      () async {
-        await ref
-            .read(sharedPreferencesProvider)
-            .setString(_websiteUrlKey, url);
-        return update(
-          (profile) => profile.copyWith(
-            websiteUrl: url,
-          ),
-        );
-      },
-    );
+  Future<void> update(String url) async {
+    await ref.read(sharedPreferencesProvider).setString(_key, url);
+    state = url;
   }
 }
 

--- a/lib/model/profile/profile_provider.g.dart
+++ b/lib/model/profile/profile_provider.g.dart
@@ -37,21 +37,34 @@ final profileImageUrlProvider = AutoDisposeFutureProvider<String>.internal(
 );
 
 typedef ProfileImageUrlRef = AutoDisposeFutureProviderRef<String>;
-String _$profileNotifierHash() => r'de9bb8958c5039950831aafcb142ddffc400b3a6';
+String _$userNameHash() => r'4378d6fab50d642b3988b2e61a46b0447cd61cbb';
 
-/// See also [ProfileNotifier].
-@ProviderFor(ProfileNotifier)
-final profileNotifierProvider =
-    AutoDisposeAsyncNotifierProvider<ProfileNotifier, Profile>.internal(
-  ProfileNotifier.new,
-  name: r'profileNotifierProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$profileNotifierHash,
+/// See also [UserName].
+@ProviderFor(UserName)
+final userNameProvider = AutoDisposeNotifierProvider<UserName, String>.internal(
+  UserName.new,
+  name: r'userNameProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$userNameHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
-typedef _$ProfileNotifier = AutoDisposeAsyncNotifier<Profile>;
+typedef _$UserName = AutoDisposeNotifier<String>;
+String _$websiteUrlHash() => r'66ffd84462813fb9f8841f88da0594d961d11158';
+
+/// See also [WebsiteUrl].
+@ProviderFor(WebsiteUrl)
+final websiteUrlProvider =
+    AutoDisposeNotifierProvider<WebsiteUrl, String>.internal(
+  WebsiteUrl.new,
+  name: r'websiteUrlProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$websiteUrlHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$WebsiteUrl = AutoDisposeNotifier<String>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/ui/screen/profile/profile.dart
+++ b/lib/ui/screen/profile/profile.dart
@@ -179,9 +179,7 @@ class _Name extends ConsumerStatefulWidget {
 class _NameState extends ConsumerState<_Name> {
   @override
   Widget build(BuildContext context) {
-    final name = ref.watch(
-      profileNotifierProvider.select((value) => value.valueOrNull?.name ?? ''),
-    );
+    final name = ref.watch(userNameProvider);
     final localization = ref.watch(localizationProvider);
 
     return _ProfileDisplay(
@@ -189,7 +187,7 @@ class _NameState extends ConsumerState<_Name> {
       style: Theme.of(context).textTheme.headlineMedium,
       tooltip: localization.editName,
       placeholder: localization.userName,
-      onEditCompleted: ref.read(profileNotifierProvider.notifier).updateName,
+      onEditCompleted: ref.read(userNameProvider.notifier).update,
     );
   }
 }
@@ -199,10 +197,7 @@ class _Website extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final websiteUrl = ref.watch(
-      profileNotifierProvider
-          .select((value) => value.valueOrNull?.websiteUrl ?? ''),
-    );
+    final websiteUrl = ref.watch(websiteUrlProvider);
     final localization = ref.watch(localizationProvider);
 
     return _ProfileDisplay(
@@ -210,8 +205,7 @@ class _Website extends ConsumerWidget {
       style: Theme.of(context).textTheme.bodyLarge,
       tooltip: localization.editUrl,
       placeholder: localization.selfIntroductionUrl,
-      onEditCompleted:
-          ref.read(profileNotifierProvider.notifier).updateWebsiteUrl,
+      onEditCompleted: ref.read(websiteUrlProvider.notifier).update,
     );
   }
 }

--- a/lib/ui/screen/profile/profile.dart
+++ b/lib/ui/screen/profile/profile.dart
@@ -177,8 +177,6 @@ class _Name extends ConsumerStatefulWidget {
 }
 
 class _NameState extends ConsumerState<_Name> {
-  bool _isEditing = false;
-
   @override
   Widget build(BuildContext context) {
     final name = ref.watch(
@@ -186,37 +184,11 @@ class _NameState extends ConsumerState<_Name> {
     );
     final localization = ref.watch(localizationProvider);
 
-    if (_isEditing || name.isEmpty) {
-      return _InputArea(
-        placeholder: localization.userName,
-        initialValue: name,
-        onCompleted: (value) {
-          setState(() {
-            _isEditing = false;
-          });
-          ref.read(profileNotifierProvider.notifier).updateName(value);
-        },
-      );
-    }
-
-    return InkWell(
-      onTap: () => setState(() {
-        _isEditing = true;
-      }),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: 16,
-          vertical: 8,
-        ),
-        child: SizedBox(
-          width: double.infinity,
-          child: Text(
-            name,
-            textAlign: TextAlign.center,
-            style: Theme.of(context).textTheme.headlineMedium,
-          ),
-        ),
-      ),
+    return _ProfileDisplay(
+      text: name,
+      style: Theme.of(context).textTheme.headlineMedium,
+      placeholder: localization.userName,
+      onEditCompleted: ref.read(profileNotifierProvider.notifier).updateName,
     );
   }
 }
@@ -227,15 +199,76 @@ class _Website extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final websiteUrl = ref.watch(
-      profileNotifierProvider.select((value) => value.valueOrNull?.websiteUrl),
+      profileNotifierProvider
+          .select((value) => value.valueOrNull?.websiteUrl ?? ''),
     );
     final localization = ref.watch(localizationProvider);
-    return _InputArea(
-      placeholder: localization.selfIntroductionUrl,
-      initialValue: websiteUrl,
-      onCompleted: (value) =>
-          ref.read(profileNotifierProvider.notifier).updateWebsiteUrl(value),
+
+    return _ProfileDisplay(
+      text: websiteUrl,
       style: Theme.of(context).textTheme.bodyLarge,
+      placeholder: localization.selfIntroductionUrl,
+      onEditCompleted:
+          ref.read(profileNotifierProvider.notifier).updateWebsiteUrl,
+    );
+  }
+}
+
+class _ProfileDisplay extends StatefulWidget {
+  const _ProfileDisplay({
+    required this.text,
+    required this.style,
+    required this.placeholder,
+    required this.onEditCompleted,
+  });
+
+  final String text;
+  final TextStyle? style;
+  final String placeholder;
+  final void Function(String) onEditCompleted;
+
+  @override
+  State<_ProfileDisplay> createState() => __ProfileDisplayState();
+}
+
+class __ProfileDisplayState extends State<_ProfileDisplay> {
+  bool _isEditing = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isEditing || widget.text.isEmpty) {
+      return _InputArea(
+        placeholder: widget.placeholder,
+        initialValue: widget.text,
+        style: widget.style,
+        onCompleted: (value) {
+          setState(() {
+            _isEditing = false;
+          });
+          widget.onEditCompleted(value);
+        },
+      );
+    }
+
+    return InkWell(
+      onTap: () => setState(() {
+        _isEditing = true;
+      }),
+      borderRadius: BorderRadius.circular(40),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 8,
+        ),
+        child: SizedBox(
+          width: double.infinity,
+          child: Text(
+            widget.text,
+            textAlign: TextAlign.center,
+            style: widget.style,
+          ),
+        ),
+      ),
     );
   }
 }
@@ -281,7 +314,7 @@ class __InputAreaState extends State<_InputArea> {
     return TextField(
       controller: _controller,
       focusNode: _focusNode,
-      style: widget.style ?? Theme.of(context).textTheme.headlineMedium,
+      style: widget.style,
       maxLines: 1,
       textAlign: TextAlign.center,
       decoration: InputDecoration(

--- a/lib/ui/screen/profile/profile.dart
+++ b/lib/ui/screen/profile/profile.dart
@@ -187,6 +187,7 @@ class _NameState extends ConsumerState<_Name> {
     return _ProfileDisplay(
       text: name,
       style: Theme.of(context).textTheme.headlineMedium,
+      tooltip: localization.editName,
       placeholder: localization.userName,
       onEditCompleted: ref.read(profileNotifierProvider.notifier).updateName,
     );
@@ -207,6 +208,7 @@ class _Website extends ConsumerWidget {
     return _ProfileDisplay(
       text: websiteUrl,
       style: Theme.of(context).textTheme.bodyLarge,
+      tooltip: localization.editUrl,
       placeholder: localization.selfIntroductionUrl,
       onEditCompleted:
           ref.read(profileNotifierProvider.notifier).updateWebsiteUrl,
@@ -218,12 +220,14 @@ class _ProfileDisplay extends StatefulWidget {
   const _ProfileDisplay({
     required this.text,
     required this.style,
+    required this.tooltip,
     required this.placeholder,
     required this.onEditCompleted,
   });
 
   final String text;
   final TextStyle? style;
+  final String tooltip;
   final String placeholder;
   final void Function(String) onEditCompleted;
 
@@ -251,22 +255,25 @@ class __ProfileDisplayState extends State<_ProfileDisplay> {
       );
     }
 
-    return InkWell(
-      onTap: () => setState(() {
-        _isEditing = true;
-      }),
-      borderRadius: BorderRadius.circular(40),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: 16,
-          vertical: 8,
-        ),
-        child: SizedBox(
-          width: double.infinity,
-          child: Text(
-            widget.text,
-            textAlign: TextAlign.center,
-            style: widget.style,
+    return Tooltip(
+      message: widget.tooltip,
+      child: InkWell(
+        onTap: () => setState(() {
+          _isEditing = true;
+        }),
+        borderRadius: BorderRadius.circular(40),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 8,
+          ),
+          child: SizedBox(
+            width: double.infinity,
+            child: Text(
+              widget.text,
+              textAlign: TextAlign.center,
+              style: widget.style,
+            ),
           ),
         ),
       ),

--- a/lib/ui/screen/profile/profile.dart
+++ b/lib/ui/screen/profile/profile.dart
@@ -241,6 +241,7 @@ class __ProfileDisplayState extends State<_ProfileDisplay> {
         placeholder: widget.placeholder,
         initialValue: widget.text,
         style: widget.style,
+        initialFocus: _isEditing,
         onCompleted: (value) {
           setState(() {
             _isEditing = false;
@@ -278,12 +279,14 @@ class _InputArea extends StatefulWidget {
     required this.placeholder,
     required this.initialValue,
     required this.onCompleted,
+    required this.initialFocus,
     this.style,
   });
 
   final String placeholder;
   final String? initialValue;
   final void Function(String) onCompleted;
+  final bool initialFocus;
   final TextStyle? style;
 
   @override
@@ -298,7 +301,9 @@ class __InputAreaState extends State<_InputArea> {
 
   @override
   void initState() {
-    _focusNode.requestFocus();
+    if (widget.initialFocus) {
+      _focusNode.requestFocus();
+    }
     super.initState();
   }
 

--- a/lib/ui/screen/profile/profile.dart
+++ b/lib/ui/screen/profile/profile.dart
@@ -290,7 +290,7 @@ class _InputArea extends StatefulWidget {
 }
 
 class __InputAreaState extends State<_InputArea> {
-  late final TextEditingController _controller = TextEditingController(
+  final _controller = TextEditingController(
     text: widget.initialValue,
   );
   final _focusNode = FocusNode();

--- a/lib/ui/screen/profile/profile.dart
+++ b/lib/ui/screen/profile/profile.dart
@@ -169,16 +169,11 @@ class _IconImage extends StatelessWidget {
   }
 }
 
-class _Name extends ConsumerStatefulWidget {
+class _Name extends ConsumerWidget {
   const _Name();
 
   @override
-  ConsumerState<_Name> createState() => _NameState();
-}
-
-class _NameState extends ConsumerState<_Name> {
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final name = ref.watch(userNameProvider);
     final localization = ref.watch(localizationProvider);
 


### PR DESCRIPTION
## Description

- Make profile page data to be displayed by `Text` instead of `TextField` when data is not empty.
  - On tap the data, change `Text` to `TextField`.
- Isolate profile data in providers (from https://github.com/FlutterKaigi/conference-app-2023/pull/229#discussion_r1381179056).

## Type of change

Please delete options that are not relevant.

- [x] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Style
- [ ] Documentation
- [ ] CI/CD
- [ ] Other

## How Has This Been Tested?

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] My code has been formatted with `flutter format lib`.
- [x] My code has been fixed with `dart fix --apply lib`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
